### PR TITLE
feat: Mult-line`strip`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "clippy-tracing"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "clap",
  "itertools",

--- a/clippy-tracing/src/main.rs
+++ b/clippy-tracing/src/main.rs
@@ -76,15 +76,21 @@ impl From<StripVisitor> for String {
 impl syn::visit::Visit<'_> for StripVisitor {
     fn visit_impl_item_fn(&mut self, i: &syn::ImplItemFn) {
         if let Some(instrument) = find_instrumented(&i.attrs) {
-            let line = instrument.span().start().line - 1;
-            self.0.remove(&line);
+            let start = instrument.span().start().line - 1;
+            let end = instrument.span().end().line;
+            for line in start..end {
+                self.0.remove(&line);
+            }
         }
         self.visit_block(&i.block);
     }
     fn visit_item_fn(&mut self, i: &syn::ItemFn) {
         if let Some(instrument) = find_instrumented(&i.attrs) {
-            let line = instrument.span().start().line - 1;
-            self.0.remove(&line);
+            let start = instrument.span().start().line - 1;
+            let end = instrument.span().end().line;
+            for line in start..end {
+                self.0.remove(&line);
+            }
         }
         self.visit_block(&i.block);
     }

--- a/clippy-tracing/tests/integration_tests.rs
+++ b/clippy-tracing/tests/integration_tests.rs
@@ -95,6 +95,23 @@ fn strip_one() {
     const EXPECTED: &str = "fn main() { }";
     strip(GIVEN, EXPECTED);
 }
+
+#[test]
+fn strip_two() {
+    const GIVEN: &str =
+        "#[tracing::instrument(    \nlevel = \"trace\",\n    skip()\n)]\nfn main() { }";
+    const EXPECTED: &str = "fn main() { }";
+    strip(GIVEN, EXPECTED);
+}
+
+#[test]
+fn strip_three() {
+    const EXPECTED: &str = "impl Unit {\n    fn one() {}\n}";
+    const GIVEN: &str =
+        "impl Unit {\n    #[tracing::instrument(level = \"trace\", skip())]\n    fn one() {}\n}";
+    strip(GIVEN, EXPECTED);
+}
+
 #[test]
 fn readme() {
     const GIVEN: &str = r#"fn main() {


### PR DESCRIPTION
Makes `strip` works to remove the macro when its formatted across multiple lines.

Closes https://github.com/JonathanWoollett-Light/clippy-tracing/issues/6