### PR TITLE
feat: `log_instrument`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,8 +36,13 @@ jobs:
     - name: Audit
       run: cargo audit
       
+    # Install and cache `cargo-hack`
+    - uses: taiki-e/cache-cargo-install-action@v1
+      with:
+        tool: cargo-hack
+
     - name: Check
-      run: cargo check
+      run: cargo hack check --feature-powerset --no-dev-deps
       
     - name: Clippy
       run: |
@@ -53,7 +58,7 @@ jobs:
       run: cargo udeps
 
     - name: Test
-      run: cargo test
+      run: cargo hack test --feature-powerset
 
     # https://github.com/taiki-e/cargo-llvm-cov#continuous-integration
 

--- a/README.md
+++ b/README.md
@@ -93,3 +93,8 @@ mod tests {
     }
 }
 ```
+
+
+### `log`
+
+Supports [`log_instrument`](https://github.com/JonathanWoollett-Light/log-instrument) when compiled with the `log` feature.

--- a/clippy-tracing/Cargo.toml
+++ b/clippy-tracing/Cargo.toml
@@ -18,3 +18,6 @@ itertools = "0.11.0"
 
 [dev-dependencies]
 uuid = { version = "1.4.1", features = ["v4"] }
+
+[features]
+log = []

--- a/clippy-tracing/src/main.rs
+++ b/clippy-tracing/src/main.rs
@@ -183,6 +183,7 @@ impl syn::visit::Visit<'_> for FixVisitor {
 }
 
 /// Returns the instrument macro for a given function signature.
+#[cfg(not(feature = "log"))]
 fn instrument(sig: &syn::Signature) -> String {
     let iter = sig.inputs.iter().flat_map(|arg| match arg {
         syn::FnArg::Receiver(_) => vec![String::from("self")],
@@ -201,6 +202,12 @@ fn instrument(sig: &syn::Signature) -> String {
     let args = itertools::intersperse(iter, String::from(", ")).collect::<String>();
 
     format!("#[tracing::instrument(level = \"trace\", skip({args}))]")
+}
+
+/// Returns the instrument macro for a given function signature.
+#[cfg(feature = "log")]
+fn instrument(_sig: &syn::Signature) -> String {
+    String::from("#[log_instrument::instrument]")
 }
 
 use std::process::ExitCode;


### PR DESCRIPTION
Adds a compile-time features to switch `clippy-tracing` to be used for `log_instrument`.